### PR TITLE
Fixed minor grammatical errors in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ A good understanding of matroid theory is required to fully utilize these script
 
 This project looks at the problem of bounding the size (i.e. number of elements ) of a binary matroid as a function of its rank, given that one is excluding certain matroid minors.   
 
-We aim to look at this problem in the context of binary matroids where which exclude certain small matroids as minors.  For example, it has been conjectured that for a (simple) binary matroid M, the maximum number of elements
-of M is at most  9/2 r(M), where r(M) denote the rank of M.  In this project, we follow the methods of Kung et al by first looking at the cases where r(M) is small with the help of a computer, and then using this to set up
-and inductive proof to establish good bounds.
+We aim to look at this problem in the context of binary matroids where we exclude certain small matroids as minors.  For example, it has been conjectured that for a (simple) binary matroid M, the maximum number of elements
+of M is at most  9/2 r(M), where r(M) denotes the rank of M.  In this project, we follow the methods of Kung et al by first looking at the cases where r(M) is small with the help of a computer, and then using this to set up
+an inductive proof to establish good bounds.
 
 ## Note
 
-These methods have not been modularized nor are fully functional on other computers without modification. These methods were not meant to be used outside of research purposes.
+These methods have not been modularized nor are they fully functional on other computers without modification. These methods were not meant to be used outside of research purposes.
 
 ## Methods
 


### PR DESCRIPTION
Issues were small things such as "and" where "an" should be and a missing "s".